### PR TITLE
Cross build prereq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@ PREFIX ?= /usr
 # Export VERSION and PREFIX so sub-make knows about them
 export VERSION PREFIX
 
+# Export include and lib path
+export LIBLONGHORN_PREFIX
+
+# Export target host sysroot path
+export TARGET_SYSROOT
+
 # Export the feature switches so sub-make knows about them
 export ISCSI_RDMA
 export CEPH_RBD

--- a/usr/Makefile
+++ b/usr/Makefile
@@ -3,6 +3,8 @@ libdir ?= $(PREFIX)/lib/tgt
 
 SYSTEM_HEADERS = $(TARGET_SYSROOT)/usr/include
 
+LIBLONGHORN_PREFIX ?= $(TARGET_SYSROOT)/usr
+
 ifneq ($(shell test -e $(SYSTEM_HEADERS)/linux/signalfd.h && echo 1),)
 CFLAGS += -DUSE_SIGNALFD
 endif
@@ -39,6 +41,7 @@ LIBS += -libverbs -lrdmacm
 endif
 
 INCLUDES += -I.
+INCLUDES += -I$(LIBLONGHORN_PREFIX)/include
 
 CFLAGS += -D_GNU_SOURCE
 CFLAGS += $(INCLUDES)
@@ -67,6 +70,7 @@ TGTD_OBJS += tgtd.o mgmt.o target.o scsi.o log.o driver.o util.o work.o \
 TGTD_DEP = $(TGTD_OBJS:.o=.d)
 
 LDFLAGS = -Wl,-E,-rpath=$(libdir)
+LDFLAGS += -L$(LIBLONGHORN_PREFIX)/lib
 
 ifneq ($(TARGET_SYSROOT),)
 LDFLAGS_SHARED = --sysroot=$(TARGET_SYSROOT)

--- a/usr/Makefile
+++ b/usr/Makefile
@@ -68,6 +68,10 @@ TGTD_DEP = $(TGTD_OBJS:.o=.d)
 
 LDFLAGS = -Wl,-E,-rpath=$(libdir)
 
+ifneq ($(TARGET_SYSROOT),)
+LDFLAGS_SHARED = --sysroot=$(TARGET_SYSROOT)
+endif
+
 .PHONY:all
 all: $(PROGRAMS) $(MODULES)
 
@@ -101,10 +105,10 @@ tgtimg: $(TGTIMG_OBJS)
 	$(CC) -shared $(CFLAGS) $*.c -o $*.so
 
 bs_rbd.so: bs_rbd.c
-	$(CC) -shared $(CFLAGS) bs_rbd.c -o bs_rbd.so -lrados -lrbd
+	$(CC) $(LDFLAGS_SHARED) -shared $(CFLAGS) bs_rbd.c -o bs_rbd.so -lrados -lrbd
 
 bs_glfs.so: bs_glfs.c
-	$(CC) -I/usr/include/glusterfs/api -shared $(CFLAGS) bs_glfs.c -o bs_glfs.so -lgfapi
+	$(CC) $(LDFLAGS_SHARED) -shared $(CFLAGS) -o bs_glfs.so -lgfapi
 
 .PHONY: install
 install: $(PROGRAMS) $(MODULES)

--- a/usr/Makefile
+++ b/usr/Makefile
@@ -1,11 +1,13 @@
 sbindir ?= $(PREFIX)/sbin
 libdir ?= $(PREFIX)/lib/tgt
 
-ifneq ($(shell test -e /usr/include/linux/signalfd.h && echo 1),)
+SYSTEM_HEADERS = $(TARGET_SYSROOT)/usr/include
+
+ifneq ($(shell test -e $(SYSTEM_HEADERS)/linux/signalfd.h && echo 1),)
 CFLAGS += -DUSE_SIGNALFD
 endif
 
-ifneq ($(shell test -n $(shell find /usr/include -name "timerfd.h" | head -n1) && echo 1),)
+ifneq ($(shell test -n $(shell find $(SYSTEM_HEADERS) -name "timerfd.h" | head -n1) && echo 1),)
 CFLAGS += -DUSE_TIMERFD
 endif
 
@@ -25,7 +27,7 @@ ifneq ($(SD_NOTIFY),)
 CFLAGS += -DUSE_SYSTEMD
 endif
 
-ifneq ($(shell test -e /usr/include/libaio.h && echo 1),)
+ifneq ($(shell test -e $(SYSTEM_HEADERS)/libaio.h && echo 1),)
 CFLAGS += -DUSE_EVENTFD
 TGTD_OBJS += bs_aio.o
 LIBS += -laio


### PR DESCRIPTION
Hi,

This branch holds some prereqs to cross-compile tgt in my environment:

* raspberrypi toolchain in ~/raspberrypi/tools
* raspberrypi system fs copied in ~/raspberrypi/rootfs
* cross-compiled liblonghorn installed in ~/raspberrypi/dest

Bellow the script I use to build tgt.

Alexis

```
#!/bin/sh
RPI=~/raspberrypi
RPITOOLS=$RPI/tools
RPIROOTFS=$RPI/rootfs
RPIDEST=$RPI/dest
RPIABI=arm-linux-gnueabihf
RPICC=$RPITOOLS/arm-bcm2708/gcc-linaro-${RPIABI}-raspbian/bin/${RPIABI}-gcc

cd tgt
LANG=CC CC=$RPICC TARGET_SYSROOT=$RPIROOTFS LIBLONGHORN_PREFIX=$RPIDEST/usr DESTDIR=$RPIDEST GLFS_BD=1 CEPH_RBD=1 make -e clean
LANG=CC CC=$RPICC TARGET_SYSROOT=$RPIROOTFS LIBLONGHORN_PREFIX=$RPIDEST/usr DESTDIR=$RPIDEST GLFS_BD=1 CEPH_RBD=1 make -e install
cd -
```